### PR TITLE
Changed 'name' parameter of the GET endpoints to avoid confusion #5

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ def get_transport_line(tup):
         "public_id": pub_id,
         "internal_id": int_id,
         "transport_type": trans_type,
-        "name": name,
+        "line_name": name,
         "operator": operator,
         "destination": dest,
         "num_stops": stops
@@ -43,7 +43,7 @@ def make_stop(stop_id, lat, lon, name, town, area_code, access_wc, access_vi):
         "stop_code": stop_id,
         "lat": lat,
         "lon": lon,
-        "name": name,
+        "stop_name": name,
         "town": town,
         "area_code": area_code,
         "accessibility_wheelchair": access_wc,
@@ -83,7 +83,7 @@ def get_transport_line_stop(tup):
     stop_code, stop_name, order_number, int_id, direction = tup
     return {
         "stop_code": stop_code,
-        "name": stop_name,
+        "stop_name": stop_name,
         "order_number": order_number,
         "internal_id": int_id,
         "direction": direction


### PR DESCRIPTION
I changed the 'name' parameter of the `get_stops`, `get_lines` and `get_line_info` to avoid confusion (mainly for our delay stream).